### PR TITLE
chore: add workflows to use as template

### DIFF
--- a/.github/templates/manifest.yaml
+++ b/.github/templates/manifest.yaml
@@ -1,0 +1,32 @@
+version: "2"
+
+name: %PRETTY_NAME%
+description: %PRETTY_NAME%
+
+service_account:
+  display_name: %PRETTY_NAME% Bot
+
+functions:
+  - name: extraction
+    description: Extraction function for %PRETTY_NAME%
+
+keyring_types:
+  - id: example-connection
+    name: Example Connection
+    description: Example Connection
+    kind: "Secret"
+    is_subdomain: true
+    secret_config:
+      secret_transform: ".token" # a JQ query
+      fields:
+        - id: token
+          name: Token
+          description: Example API token
+
+imports:
+  - slug: %PROJECT_NAME%
+    display_name: %PRETTY_NAME%
+    description: %PRETTY_NAME%
+    extractor_function: extraction
+    allowed_connection_types:
+      - example-connection

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -1,0 +1,59 @@
+name: Set up the repository
+on:
+    push:
+        branches: [main]
+jobs:
+  cleanup:
+    name: Set up the repository
+    runs-on: ubuntu-latest
+    if: github.event.repository.name != 'adaas-template'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Replace templates
+        run: |
+          shopt -s dotglob
+
+          export LC_CTYPE=C
+          export LANG=C
+
+          # Project name is lowercase repository name (used in configs)
+          PROJECT_NAME="${GITHUB_REPOSITORY,,}" # Of form owner/repo
+          PROJECT_NAME="${PROJECT_NAME##*/}" # Just the repo name
+          
+          # Pretty name is how it's displayed in the README (spaces and starting case)
+          # Since it can contain spaces, it has to be escaped in the sed command
+          PRETTY_NAME="$(echo "$PROJECT_NAME" | sed 's/-/ /g; s/\b\(.\)/\u\1/g')"
+          ESCAPED_PRETTY_NAME="$(echo "$PRETTY_NAME" | sed 's/ /\\ /g')"
+          
+          echo "Project name: '$PROJECT_NAME'"
+          echo "Pretty name: '$PRETTY_NAME'"
+          
+          echo "Replacing pretty name: %PRETTY_NAME% -> '$PRETTY_NAME'"
+          find .github/templates -type f -exec sed -i "s/%PRETTY_NAME%/$ESCAPED_PRETTY_NAME/g" {} \;
+          
+          echo "Replacing project name: %PROJECT_NAME% -> '$PROJECT_NAME'"
+          find .github/templates -type f -exec sed -i "s/%PROJECT_NAME%/$PROJECT_NAME/g" {} \;
+          
+
+          echo "Moving template files to the root of the repository"
+          rm -rf manifest.yaml
+          mv -f .github/templates/* .
+          rm -rf .github
+
+      - name: Commit
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit --amend --no-edit
+
+      - name: Push
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+          force: true

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ This GitHub repository provides a template with example code to implement an Air
 - Rename `Makefile.variable.example` to `Makefile.variable`.
 - In `Makefile.variable` set the slug of your organization, and your email.
 
-NOTE: Update this field with the appropriate connection type configuration.
-
 4\. Build the Snap-in using the following command:
 
 ```bash
@@ -34,7 +32,7 @@ make build
 make deploy
 ```
 
-NOTE: This process may take some time. Command authenticates you to the org using the DevRev CLI, prompts you to select the keyring where you saved GitHub PAT and creates a Snap-in package, its Snap-in version, and finally the Snap-in draft.
+NOTE: This process may take some time. Command authenticates you to the org using the DevRev CLI, creates a Snap-in package, its Snap-in version, and finally the Snap-in draft.
 
 6\. After the Snap-in draft is created, install the Snap-in in the DevRev UI (`Settings` -> `Snap-ins` -> `Install snap-in`).
 


### PR DESCRIPTION
## Summary

Adding GitHub workflows to update manifest values with the repository name on creation of new repositories with this template as base. In particular, `manifest.yaml` will have the `name`, `description`, `service_account,display_name` and `imports` updated with repository's name.

## Pre-merge

- Ensure that we have the relevant token added as a secret for the GitHub action.