### PR TITLE
Update template to use latest library

### DIFF
--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@devrev/ts-adaas": "0.0.1",
+        "@devrev/ts-adaas": "0.0.2",
         "axios": "^1.5.1",
         "dotenv": "^16.0.3",
         "js-jsonl": "^1.1.1",
@@ -1832,9 +1832,9 @@
       }
     },
     "node_modules/@devrev/ts-adaas": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@devrev/ts-adaas/-/ts-adaas-0.0.1.tgz",
-      "integrity": "sha512-nOvOvPRtEDoI1SGILYFrVoQVmq8jeyRfzZDMiNuk8kXpaZ1eKVOfMvVIadhI9kQ0pNuUaQWNHkKd1Nu7E5i0HQ==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@devrev/ts-adaas/-/ts-adaas-0.0.2.tgz",
+      "integrity": "sha512-qBIibkgTVZoes9ROZU8YEvpBxWMxv4ScVNB63Dwu820aC5hdzHn7YbUPBJFPqTwDxvqK8tgIvuCtIkJbGZwsJw==",
       "dependencies": {
         "@devrev/typescript-sdk": "^1.1.27",
         "axios": "^1.5.1",
@@ -12040,9 +12040,9 @@
       }
     },
     "@devrev/ts-adaas": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@devrev/ts-adaas/-/ts-adaas-0.0.1.tgz",
-      "integrity": "sha512-nOvOvPRtEDoI1SGILYFrVoQVmq8jeyRfzZDMiNuk8kXpaZ1eKVOfMvVIadhI9kQ0pNuUaQWNHkKd1Nu7E5i0HQ==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@devrev/ts-adaas/-/ts-adaas-0.0.2.tgz",
+      "integrity": "sha512-qBIibkgTVZoes9ROZU8YEvpBxWMxv4ScVNB63Dwu820aC5hdzHn7YbUPBJFPqTwDxvqK8tgIvuCtIkJbGZwsJw==",
       "requires": {
         "@devrev/typescript-sdk": "^1.1.27",
         "axios": "^1.5.1",

--- a/code/package.json
+++ b/code/package.json
@@ -55,7 +55,7 @@
     "yargs": "^17.6.2"
   },
   "dependencies": {
-    "@devrev/ts-adaas": "0.0.1",
+    "@devrev/ts-adaas": "0.0.2",
     "axios": "^1.5.1",
     "dotenv": "^16.0.3",
     "js-jsonl": "^1.1.1",

--- a/code/src/functions/extraction/index.ts
+++ b/code/src/functions/extraction/index.ts
@@ -1,10 +1,10 @@
-import { AirdropEvent, DemoExtractor } from '@devrev/ts-adaas';
+import { AirdropEvent, createAdapter, DemoExtractor } from '@devrev/ts-adaas';
 
 const run = async (events: AirdropEvent[]) => {
   for (const event of events) {
-    console.log('Event: ' + JSON.stringify(event));
-    const extractor = new DemoExtractor();
-    await extractor.run(event);
+    const adapter = await createAdapter<object>(event, {});
+    const demoExtractor = new DemoExtractor(event, adapter);
+    await demoExtractor.run();
   }
 };
 


### PR DESCRIPTION
Because we switched to State API, instantiation of adapter is now asynchronous function in library and we need to await for it to get the existing state or create if it by passing inital state and its generic interface to `createAdapter` function. 