### PR TITLE
deploy.sh: preflight manifest scopes and dev keyrings before SIP creation

### DIFF
--- a/code/scripts/deploy.sh
+++ b/code/scripts/deploy.sh
@@ -210,6 +210,55 @@ else
 fi
 echo ""
 
+# Preflight the manifest against the target org so we fail fast BEFORE creating
+# a snap-in package. Both checks below match errors we've seen in practice, and
+# both otherwise fail after SIP creation (leaving an orphan).
+
+# 1. service_account.scopes must be present for airdrop snap-ins. The CLI validator
+#    returns: "validation failed: service_account.scopes is required by the snap-in
+#    to function". Minimal heuristic: manifest must mention a scopes: block and at
+#    least the sync_snap_in:all airdrop scope.
+if ! grep -qE "^[[:space:]]*scopes:" manifest.yaml || ! grep -q "sync_snap_in:all" manifest.yaml; then
+    error "manifest.yaml is missing service_account.scopes (airdrop requires the 4 scopes under service_account.scopes.self)"
+    exit 1
+fi
+
+# 2. Every developer_keyrings[].name in the manifest must already exist in the org.
+#    Missing keyring -> "no connection exists for type(s) devrev-snap-in-secret".
+# Parse keyring names without requiring yq: grab the "- name:" entries under the
+# developer_keyrings: block.
+MANIFEST_KEYRINGS=$(awk '
+    /^developer_keyrings:/ { in_block=1; next }
+    in_block && /^[^[:space:]-]/ { in_block=0 }
+    in_block && /^[[:space:]]*-[[:space:]]*name:[[:space:]]*/ {
+        sub(/^[[:space:]]*-[[:space:]]*name:[[:space:]]*/, "")
+        gsub(/["'\'']/, "")
+        print
+    }
+' manifest.yaml)
+
+if [ -n "$MANIFEST_KEYRINGS" ]; then
+    echo "Checking developer keyrings in $DEV_ORG..."
+    ORG_KEYRINGS=$(devrev developer_keyring list 2>/dev/null | jq -r '.keyrings[].name' 2>/dev/null)
+    MISSING_KEYRINGS=()
+    while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        if ! grep -qx "$name" <<<"$ORG_KEYRINGS"; then
+            MISSING_KEYRINGS+=("$name")
+        fi
+    done <<<"$MANIFEST_KEYRINGS"
+
+    if [ ${#MISSING_KEYRINGS[@]} -gt 0 ]; then
+        error "Missing developer keyring(s) in org: ${MISSING_KEYRINGS[*]}"
+        echo "Create each one before re-running:"
+        echo "  echo '{\"client_id\":\"<ID>\",\"client_secret\":\"<SECRET>\"}' | devrev developer_keyring create oauth-secret <name>"
+        echo "  echo '<SECRET>' | devrev developer_keyring create snap-in-secret <name>"
+        exit 1
+    fi
+    success "All developer keyrings present in $DEV_ORG"
+    echo ""
+fi
+
 # Prompt for snap-in package slug (defaults to airdrop-YYYYMMDDHHMM, user can press Enter)
 DEFAULT_SLUG="airdrop-$(date +%Y%m%d%H%M)"
 SIP_SLUG=$(prompt_with_default "Enter snap-in package slug" "$DEFAULT_SLUG")


### PR DESCRIPTION
# Description
Two common airdrop-deploy failures surface *after* `snap_in_package create-one`, which leaves an orphan SIP that must be cleaned up before the user can retry. Both are detectable pre-SIP from the manifest + the authenticated CLI:

1. **Missing `service_account.scopes`** — CLI returns `validation failed: service_account.scopes is required by the snap-in to function` when the manifest only declares `service_account.display_name` and is missing the four scopes under `service_account.scopes.self`.
2. **Missing developer keyring** — CLI returns `no connection exists for type(s) devrev-snap-in-secret, please create it on the UI, and retry the command` when a `developer_keyrings` entry in the manifest has no matching keyring in the target org.

This PR adds a preflight block immediately after `devrev profiles authenticate` and before `snap_in_package create-one`: it checks both conditions and exits cleanly with a specific, actionable error message, so no orphan SIP is left behind.

The keyring parser uses `awk` so the script stays dependency-free (no `yq` required).

## Connected Issues
https://app.devrev.ai/devrev/works/ISS-303984

## Checklist
- [ ] Tests added/updated and ran with `npm run test` OR no tests needed.
- [ ] Code formatted and checked with `npm run lint`.
- [x] Added "How to test" section to the description OR this section is not needed.

## How to test
- Run `./code/scripts/deploy.sh` against a manifest missing `service_account.scopes` → exits before SIP creation with a clear error.
- Run against a manifest whose `developer_keyrings[].name` entry doesn't exist in the target org → exits listing the missing keyring(s).
- Run against a fully valid manifest → preflight passes (keyring check prints a SUCCESS line), normal flow continues.
- Run against a manifest with no `developer_keyrings` block (e.g. per-user PAT flow) → keyring check is skipped (no false positive).